### PR TITLE
CLI from S3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,0 @@
-FROM effx/effx-cli:latest

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ on:
       - master
 
 jobs:
-  build:
+  sync:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
@@ -41,5 +41,5 @@ Setting `directory` to `/github/workspace` enables syncing for **all** files wit
    - typing **`EFFX_API_KEY`** into the name field
    - pasting your effx API key into the value field
 4. The **`yml`** file for **`effx-sync-action`** will live in **`.github/workflows`**.
-5. Create a file named, **`effx.yaml`** and populate it with configurations.
+5. Create a file named, **`effx.yaml`** or matching **`*.effx.yaml`**and populate it with configurations.
 6. On pushing to **`master`**, **`effx-sync-action`** will parse your configuration file. 🥳

--- a/action.yml
+++ b/action.yml
@@ -5,9 +5,11 @@ inputs:
     description: "Directory for effx config files."
     required: true
 runs:
-  using: "docker"
-  image: "Dockerfile"
-  args:
-    - "sync"
-    - "--dir"
-    - ${{ inputs.directory }}
+  using: "composite"
+  steps:
+    - name: Download CLI
+      run: |
+        curl -Lo effx https://effx-cli.s3-us-west-2.amazonaws.com/releases/latest/effx-cli_Linux_x86_64
+        sudo install effx /usr/local/bin
+    - name: Sync all Effx Yaml files
+      run: effx sync -d ${{ inputs.directory }}


### PR DESCRIPTION
## What
 - Pulls the CLI binary from Effx's S3 bucket
 - The CLI will reflect Effx's latest version
 - The CLI binary migrated to new backend endpoint

## Why
 - Configuration files with `kind`, `version` and `spec` as the first-level keys can be consumed