### PR TITLE
Avoid Binary Name Collisions

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,8 +10,8 @@ runs:
     - name: Download CLI
       shell: bash
       run: |
-        curl -Lo effx https://effx.run/effx-cli/releases/latest/effx-cli_Linux_x86_64
-        sudo install effx /usr/local/bin
+        curl -Lo __effx_cli https://effx.run/effx-cli/releases/latest/effx-cli_Linux_x86_64
+        sudo install __effx_cli /usr/local/bin
     - name: Sync all Effx Yaml files
       shell: bash
-      run: effx sync -d ${{ inputs.directory }}
+      run: __effx_cli sync -d ${{ inputs.directory }}


### PR DESCRIPTION
## What
Changes the `effx` binary name to something less likely to conflict with a user's repository.